### PR TITLE
add retention duration SDK methods

### DIFF
--- a/src/usercloudssdk/client.py
+++ b/src/usercloudssdk/client.py
@@ -19,6 +19,8 @@ from .models import (
     AccessPolicyTemplate,
     APIErrorResponse,
     Column,
+    ColumnRetentionDurationResponse,
+    ColumnRetentionDurationsResponse,
     Edge,
     EdgeType,
     InspectTokenResponse,
@@ -29,6 +31,8 @@ from .models import (
     Purpose,
     ResourceID,
     Transformer,
+    UpdateColumnRetentionDurationRequest,
+    UpdateColumnRetentionDurationsRequest,
     UserResponse,
 )
 
@@ -210,6 +214,43 @@ class Client:
             f"/userstore/config/purposes/{purpose.id}", data=ucjson.dumps(body)
         )
         return Purpose.from_json(j)
+
+    # Retention Duration Operations
+
+    # get a specific column purpose retention duration
+    def GetSoftDeletedRetentionDurationOnColumn(
+        self, columnID: uuid.UUID, durationID: uuid.UUID
+    ) -> ColumnRetentionDurationResponse:
+        j = self._get(f"/userstore/config/columns/{columnID}/softdeletedretentiondurations/{durationID}")
+        return ColumnRetentionDurationResponse.from_json(j)
+
+    # get the retention duration for each purpose for a given column
+    def GetSoftDeletedRetentionDurationsOnColumn(
+        self, columnID: uuid.UUID
+    ) -> ColumnRetentionDurationsResponse:
+        j = self._get(f"/userstore/config/columns/{columnID}/softdeletedretentiondurations")
+        return ColumnRetentionDurationsResponse.from_json(j)
+
+    # delete a specific column purpose retention duration
+    def DeleteSoftDeletedRetentionDurationOnColumn(
+        self, columnID: uuid.UUID, durationID: uuid.UUID
+    ) -> str:
+        return self._delete(f"/userstore/config/columns/{columnID}/softdeletedretentiondurations/{durationID}")
+
+    # update a specific column purpose retention duration
+    def UpdateSoftDeletedRetentionDurationOnColumn(
+        self, columnID: uuid.UUID, durationID: uuid.UUID, req: UpdateColumnRetentionDurationRequest
+    ) -> ColumnRetentionDurationResponse:
+        j = self._put(f"/userstore/config/columns/{columnID}/softdeletedretentiondurations/{durationID}", req.to_json())
+        return ColumnRetentionDurationResponse.from_json(j)
+
+    # update the specified purpose retention durations for the column
+    # - durations can be added, deleted, or updated for each purpose
+    def UpdateSoftDeletedRetentionDurationsOnColumn(
+        self, columnID: uuid.UUID, req: UpdateColumnRetentionDurationsRequest
+    ) -> ColumnRetentionDurationsResponse:
+        j = self._post(f"/userstore/config/columns/{columnID}/softdeletedretentiondurations", data=req.to_json())
+        return ColumnRetentionDurationsResponse.from_json(j)
 
     # Access Policy Templates
 

--- a/src/usercloudssdk/client.py
+++ b/src/usercloudssdk/client.py
@@ -84,7 +84,7 @@ class Client:
 
         self._access_token = self._get_access_token()
 
-    # User Operations
+    ### User Operations
 
     def CreateUser(self) -> uuid.UUID:
         body = {}
@@ -131,7 +131,7 @@ class Client:
     def DeleteUser(self, id: uuid.UUID) -> bool:
         return self._delete(f"/authn/users/{id}")
 
-    # Column Operations
+    ### Column Operations
 
     def CreateColumn(self, column: Column, if_not_exists=False) -> Column:
         body = {"column": column.__dict__}
@@ -172,7 +172,7 @@ class Client:
         j = self._put(f"/userstore/config/columns/{column.id}", data=ucjson.dumps(body))
         return Column.from_json(j)
 
-    # Purpose Operations
+    ### Purpose Operations
 
     def CreatePurpose(self, purpose: Purpose, if_not_exists=False) -> Purpose:
         body = {"purpose": purpose.__dict__}
@@ -215,7 +215,96 @@ class Client:
         )
         return Purpose.from_json(j)
 
-    # Retention Duration Operations
+    ### Retention Duration Operations
+
+    ## Tenant Retention Duration
+
+    # A configured tenant retention duration will apply for
+    # all column purposes that do not have a configured purpose
+    # retention duration default or a configured column purpose
+    # retention duration. If a tenant retention duration is
+    # not configured, soft-deleted values will not be retained
+    # by default.
+
+    # create a tenant retention duration default
+    def CreateSoftDeletedRetentionDurationOnTenant(
+        self, req: UpdateColumnRetentionDurationRequest
+    ) -> ColumnRetentionDurationResponse:
+        j = self._post(f"/userstore/config/softdeletedretentiondurations", data=req.to_json())
+        return ColumnRetentionDurationResponse.from_json(j)
+
+    # delete a tenant retention duration default
+    def DeleteSoftDeletedRetentionDurationOnTenant(
+        self, durationID: uuid.UUID
+    ) -> str:
+        return self._delete(f"/userstore/config/softdeletedretentiondurations/{durationID}")
+
+    # get a specific tenant retention duration default
+    def GetSoftDeletedRetentionDurationOnTenant(
+        self, durationID: uuid.UUID
+    ) -> ColumnRetentionDurationResponse:
+        j = self._get(f"/userstore/config/softdeletedretentiondurations/{durationID}")
+        return ColumnRetentionDurationResponse.from_json(j)
+
+    # get tenant retention duration, or default value if not specified
+    def GetDefaultSoftDeletedRetentionDurationOnTenant(
+        self
+    ) -> ColumnRetentionDurationResponse:
+        j = self._get(f"/userstore/config/softdeletedretentiondurations")
+        return ColumnRetentionDurationResponse.from_json(j)
+
+    # update a specific tenant retention duration default
+    def UpdateSoftDeletedRetentionDurationOnTenant(
+        self, durationID: uuid.UUID, req: UpdateColumnRetentionDurationRequest
+    ) -> ColumnRetentionDurationResponse:
+        j = self._put(f"/userstore/config/softdeletedretentiondurations/{durationID}", req.to_json())
+        return ColumnRetentionDurationResponse.from_json(j)
+
+    ## Purpose Retention Durations
+
+    # A configured purpose retention duration will apply for all
+    # column purposes that include the specified purpose, unless
+    # a retention duration has been configured for a specific
+    # column purpose.
+
+    # create a purpose retention duration default
+    def CreateSoftDeletedRetentionDurationOnPurpose(
+        self, purposeID: uuid.UUID, req: UpdateColumnRetentionDurationRequest
+    ) -> ColumnRetentionDurationResponse:
+        j = self._post(f"/userstore/config/purposes/{purposeID}/softdeletedretentiondurations", data=req.to_json())
+        return ColumnRetentionDurationResponse.from_json(j)
+
+    # delete a purpose retention duration default
+    def DeleteSoftDeletedRetentionDurationOnPurpose(
+        self, purposeID: uuid.UUID, durationID: uuid.UUID
+    ) -> str:
+        return self._delete(f"/userstore/config/purposes/{purposeID}/softdeletedretentiondurations/{durationID}")
+
+    # get a specific purpose retention duration default
+    def GetSoftDeletedRetentionDurationOnPurpose(
+        self, purposeID: uuid.UUID, durationID: uuid.UUID
+    ) -> ColumnRetentionDurationResponse:
+        j = self._get(f"/userstore/config/purposes/{purposeID}/softdeletedretentiondurations/{durationID}")
+        return ColumnRetentionDurationResponse.from_json(j)
+
+    # get purpose retention duration, or default value if not specified
+    def GetDefaultSoftDeletedRetentionDurationOnPurpose(
+        self, purposeID: uuid.UUID
+    ) -> ColumnRetentionDurationResponse:
+        j = self._get(f"/userstore/config/purposes/{purposeID}/softdeletedretentiondurations")
+        return ColumnRetentionDurationResponse.from_json(j)
+
+    # update a specific purpose retention duration default
+    def UpdateSoftDeletedRetentionDurationOnPurpose(
+        self, purposeID: uuid.UUID, durationID: uuid.UUID, req: UpdateColumnRetentionDurationRequest
+    ) -> ColumnRetentionDurationResponse:
+        j = self._put(f"/userstore/config/purposes/{purposeID}/softdeletedretentiondurations/{durationID}", req.to_json())
+
+    ## Column Retention Durations
+
+    # A configured column purpose retention duration will override
+    # any configured purpose level, tenant level, or system-level
+    # default retention durations.
 
     # get a specific column purpose retention duration
     def GetSoftDeletedRetentionDurationOnColumn(
@@ -252,9 +341,7 @@ class Client:
         j = self._post(f"/userstore/config/columns/{columnID}/softdeletedretentiondurations", data=req.to_json())
         return ColumnRetentionDurationsResponse.from_json(j)
 
-    # Access Policy Templates
-
-    # Access Policies
+    ### Access Policy Templates
 
     def CreateAccessPolicyTemplate(
         self, access_policy_template: AccessPolicyTemplate, if_not_exists=False
@@ -309,7 +396,7 @@ class Client:
             params={"template_version": str(version)},
         )
 
-    # Access Policies
+    ### Access Policies
 
     def CreateAccessPolicy(
         self, access_policy: AccessPolicy, if_not_exists=False
@@ -393,7 +480,7 @@ class Client:
     def DeleteTransformer(self, id: uuid.UUID):
         return self._delete(f"/tokenizer/policies/transformation/{id}")
 
-    # Accessor Operations
+    ### Accessor Operations
 
     def CreateAccessor(self, accessor: Accessor, if_not_exists=False) -> Accessor:
         body = {"accessor": accessor.__dict__}
@@ -448,7 +535,8 @@ class Client:
 
         return self._post("/userstore/api/accessors", data=ucjson.dumps(body))
 
-    # Mutator Operations
+    ### Mutator Operations
+
     def CreateMutator(self, mutator: Mutator, if_not_exists=False) -> Mutator:
         body = {"mutator": mutator.__dict__}
 
@@ -574,7 +662,7 @@ class Client:
         j = self._post("/tokenizer/tokens/actions/lookup", data=ucjson.dumps(body))
         return j["tokens"]
 
-    # AuthZ Operations
+    ### AuthZ Operations
 
     def ListObjects(
         self, limit: int = 0, starting_after: uuid.UUID = None
@@ -745,7 +833,7 @@ class Client:
         )
         return j.get("has_attribute")
 
-    # Access token helpers
+    ### Access Token Helpers
 
     def _get_access_token(self) -> str:
         # Encode the client ID and client secret
@@ -789,7 +877,7 @@ class Client:
     def _get_headers(self) -> dict:
         return {"Authorization": f"Bearer {self._access_token}"}
 
-    # Request helpers
+    ### Request Helpers
 
     def _get(self, url, **kwargs) -> dict:
         self._refresh_access_token_if_needed()

--- a/src/usercloudssdk/models.py
+++ b/src/usercloudssdk/models.py
@@ -547,7 +547,7 @@ class ColumnRetentionDuration:
         default_duration = None if self.default_duration == None else self.default_duration.to_json()
         return ucjson.dumps(
             {
-                "duration_type": duration_type,
+                "duration_type": self.duration_type,
                 "id": str(self.id),
                 "column_id": str(self.column_id),
                 "purpose_id": str(self.purpose_id),
@@ -585,7 +585,7 @@ class UpdateColumnRetentionDurationRequest:
     def to_json(self):
         return ucjson.dumps(
             {
-                "retention_duration": self.retention_duration.to_json(),
+                "retention_duration": self.retention_duration,
             }
         )
 
@@ -658,7 +658,7 @@ class ColumnRetentionDurationsResponse:
         return ucjson.dumps(
             {
                 "max_duration": self.max_duration.to_json(),
-                "retention_durations": self.retention_durations,
+                "retention_durations": [rd.to_json() for rd in self.retention_durations],
             }
         )
 
@@ -666,7 +666,7 @@ class ColumnRetentionDurationsResponse:
     def from_json(j):
         return ColumnRetentionDurationsResponse(
             RetentionDuration.from_json(j["max_duration"]),
-            j["retention_durations"],
+            [ColumnRetentionDuration.from_json(rd) for rd in j["retention_durations"]],
         )
 
 class Validator:

--- a/src/usercloudssdk/models.py
+++ b/src/usercloudssdk/models.py
@@ -487,6 +487,187 @@ class Transformer:
             j["parameters"],
         )
 
+class RetentionDuration:
+    unit: str
+    duration: int
+
+    def __init__(self, unit, duration):
+        self.unit = unit
+        self.duration = duration
+
+    def to_json(self):
+        return ucjson.dumps(
+            {
+                "unit": self.unit,
+                "duration": self.duration,
+            }
+        )
+
+    @staticmethod
+    def from_json(j):
+        return RetentionDuration(
+            j["unit"],
+            j["duration"],
+        )
+
+class ColumnRetentionDuration:
+    duration_type: str
+    id: uuid.UUID
+    column_id: uuid.UUID
+    purpose_id: uuid.UUID
+    duration: RetentionDuration
+    use_default: bool
+    default_duration: RetentionDuration
+    purpose_name: str
+    version: int
+
+    def __init__(
+        self,
+        duration_type,
+        duration,
+        id=uuid.UUID(int=0),
+        column_id=uuid.UUID(int=0),
+        purpose_id=uuid.UUID(int=0),
+        use_default=False,
+        default_duration=None,
+        purpose_name=None,
+        version=0,
+    ):
+        self.duration_type = duration_type
+        self.id = id
+        self.column_id = column_id
+        self.purpose_id = purpose_id
+        self.duration = duration
+        self.use_default = use_default
+        self.default_duration = default_duration
+        self.purpose_name = purpose_name
+        self.version = version
+
+    def to_json(self):
+        default_duration = None if self.default_duration == None else self.default_duration.to_json()
+        return ucjson.dumps(
+            {
+                "duration_type": duration_type,
+                "id": str(self.id),
+                "column_id": str(self.column_id),
+                "purpose_id": str(self.purpose_id),
+                "duration": self.duration.to_json(),
+                "use_default": self.use_default,
+                "default_duration": default_duration,
+                "purpose_name": self.purpose_name,
+                "version": self.version,
+            }
+        )
+
+    @staticmethod
+    def from_json(j):
+        return ColumnRetentionDuration(
+            j["duration_type"],
+            RetentionDuration.from_json(j["duration"]),
+            uuid.UUID(j["id"]),
+            uuid.UUID(j["column_id"]),
+            uuid.UUID(j["purpose_id"]),
+            j["use_default"],
+            RetentionDuration.from_json(j["default_duration"]),
+            j["purpose_name"],
+            j["version"],
+        )
+
+class UpdateColumnRetentionDurationRequest:
+    retention_duration: ColumnRetentionDuration
+
+    def __init__(
+        self,
+        retention_duration,
+    ):
+        self.retention_duration = retention_duration
+
+    def to_json(self):
+        return ucjson.dumps(
+            {
+                "retention_duration": self.retention_duration.to_json(),
+            }
+        )
+
+    @staticmethod
+    def from_json(j):
+        return UpdateColumnRetentionDurationRequest(
+            ColumnRetentionDuration.from_json(j["retention_duration"]),
+        )
+
+class UpdateColumnRetentionDurationsRequest:
+    retention_durations: list[ColumnRetentionDuration]
+
+    def __init__(
+        self,
+        retention_durations,
+    ):
+        self.retention_durations = retention_durations
+
+    def to_json(self):
+        return ucjson.dumps(
+            {
+                "retention_durations": self.retention_durations,
+            }
+        )
+
+    @staticmethod
+    def from_json(j):
+        return UpdateColumnRetentionDurationsRequest(j["retention_durations"])
+
+class ColumnRetentionDurationResponse:
+    max_duration: RetentionDuration
+    retention_duration: ColumnRetentionDuration
+
+    def __init__(
+        self,
+        max_duration,
+        retention_duration,
+    ):
+        self.max_duration = max_duration
+        self.retention_duration = retention_duration
+
+    def to_json(self):
+        return ucjson.dumps(
+            {
+                "max_duration": self.max_duration.to_json(),
+                "retention_duration": self.retention_duration.to_json(),
+            }
+        )
+
+    @staticmethod
+    def from_json(j):
+        return ColumnRetentionDurationResponse(
+            RetentionDuration.from_json(j["max_duration"]),
+            ColumnRetentionDuration.from_json(j["retention_duration"]),
+        )
+
+class ColumnRetentionDurationsResponse:
+    max_duration: RetentionDuration
+    retention_durations: list[ColumnRetentionDuration]
+
+    def __init__(
+        self,
+        max_duration,
+        retention_durations,
+    ):
+        self.max_duration = max_duration
+        self.retention_durations = retention_durations
+
+    def to_json(self):
+        return ucjson.dumps(
+            {
+                "max_duration": self.max_duration.to_json(),
+                "retention_durations": self.retention_durations,
+            }
+        )
+
+    @staticmethod
+    def from_json(j):
+        return ColumnRetentionDurationsResponse(
+            RetentionDuration.from_json(j["max_duration"]),
+            j["retention_durations"],
+        )
 
 class Validator:
     id: uuid.UUID


### PR DESCRIPTION
I added SDK CRUD methods for interacting with soft-deleted retention durations for a column. I also updated the userstore sample to exercise a few of the methods.

Note that I did not add SDK methods for live retention durations, since non-indefinite retention of live data is not yet supported, and I did not add methods for tenant or purpose level defaults of retention durations, since those are not yet exposed in console.