### PR TITLE
Sync monorepo state at "Fix python lintfix script so it doesn't apply to the virutal env"

### DIFF
--- a/lintfix.sh
+++ b/lintfix.sh
@@ -6,5 +6,5 @@ PYTHON_SDK_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 # shellcheck disable=SC1091
 source "${PYTHON_SDK_DIR}/.venv/bin/activate"
 find "${PYTHON_SDK_DIR}/src" -print0 -type f -name "*.py" | xargs pyupgrade --py39-plus
-black "${PYTHON_SDK_DIR}"
-isort --profile black "${PYTHON_SDK_DIR}"
+black "${PYTHON_SDK_DIR}/src"
+isort --profile black "${PYTHON_SDK_DIR}/src"


### PR DESCRIPTION
Syncing from userclouds/userclouds@7f5998cfd91cc9cccfaea7fee3b5bb662ff4ccbe