### PR TITLE
Sync monorepo state at "Fix handling HTTP 404 responses to some HTTP DELETE API calls"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.0.15 -- UNPUBLISHED ##
 
 * Fix future compatibility (make sure the SDK doesn't break if server sends new fields)
+* Fix handling HTTP 404 responses to some HTTP DELETE API calls
 
 ## 1.0.14 -- 12-10-2023 ##
 

--- a/src/usercloudssdk/client.py
+++ b/src/usercloudssdk/client.py
@@ -977,7 +977,8 @@ class Client:
         args = self._request_kwargs.copy()
         args.update(kwargs)
         resp = self._client.delete(url, headers=self._get_headers(), **args)
-
+        if resp.status_code == 404:
+            return False
         if resp.status_code >= 400:
             resp_json = ucjson.loads(resp.text)
             err = Error.from_json(resp_json)


### PR DESCRIPTION
Syncing from userclouds/userclouds@b928f25c10791fe1a48649ab040b36d681c71ba0