### PR TITLE
Sync monorepo state at "[python sdk] Add `to_dict()` method to the Address class to make it easier to serialize it into user row when creating or modifying a user."

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 - Add GetConsentedPurposesForUser method to the Python SDK Client.
 - Add `__repr__` and `__str__` methods to some models to improve DX.
+- Add `to_dict()` method to the Address class to make it easier to serialize it into user row when creating or modifying a user.
 
 ## 1.4.0 - 02-02-2024
 

--- a/src/usercloudssdk/models.py
+++ b/src/usercloudssdk/models.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import datetime
 import uuid
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 
 import iso8601
 
@@ -990,6 +990,8 @@ class ColumnConsentedPurposes:
 
 @dataclass
 class Address:
+    """Address dataclass for usercloudssdk - can be used with columns of address type when creating or modifying users"""
+
     country: str | None = None
     name: str | None = None
     organization: str | None = None
@@ -1015,6 +1017,9 @@ class Address:
             post_code=json_data["post_code"],
             sorting_code=json_data["sorting_code"],
         )
+
+    def to_dict(self) -> dict:
+        return {k: v for k, v in asdict(self).items() if v}
 
 
 @dataclass


### PR DESCRIPTION
Syncing from userclouds/userclouds@f51f3fee5f0e49de12684ae18c84a73741c63818