### PR TITLE
Sync monorepo state at "Bump cryptography from 42.0.4 to 43.0.1 in /public-repos/sdk-python"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 certifi==2024.7.4
 cffi==1.15.1
 charset-normalizer==2.1.1
-cryptography==42.0.4
+cryptography==43.0.1
 idna==3.7
 iso8601==1.1.0
 pycparser==2.21


### PR DESCRIPTION
Syncing from userclouds/userclouds@6c866e7c66e04aaaa52d0073c9b6547ec2be402e