### PR TITLE
Sync monorepo state at "Use a specific ubuntu version when running GHA CI"

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,7 +5,7 @@ on:
       - 'v*'
 jobs:
   build-and-release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
Syncing from userclouds/userclouds@e03089b75927e29355f2cad2a3cdab7484d58971